### PR TITLE
asp-plot v2.0.0; add missing pyyaml dep and sync entry points

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "asp-plot" %}
-{% set version = "1.19.0" %}
+{% set version = "2.0.0" %}
 {% set python_min = "3.11" %}
 
 package:
@@ -8,16 +8,18 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/asp_plot-{{ version }}.tar.gz
-  sha256: 119498e8a18c6a62d29cb73ea84bd19f75582acb5824c280e49c2f4393520630
+  sha256: 0a3f6725fd893c3058f120810f5f123bcf9ad712495431918c7ca4172ee06a53
 
 build:
   noarch: python
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
-    - asp_plot = asp_plot.cli.asp_plot:main
+    - asp_report = asp_plot.cli.asp_report:main
     - csm_camera_plot = asp_plot.cli.csm_camera_plot:main
     - stereo_geom = asp_plot.cli.stereo_geom:main
+    - request_planetary_altimetry = asp_plot.cli.request_planetary_altimetry:main
+    - gallery = asp_plot.cli.gallery:main
 
 requirements:
   host:
@@ -40,16 +42,19 @@ requirements:
     - rioxarray
     - scipy
     - shapely
-    - sliderule
+    - pyyaml
+    - sliderule >=5.3.0
     - xarray
 
 test:
   imports:
     - asp_plot
   commands:
-    - asp_plot --help
+    - asp_report --help
     - csm_camera_plot --help
     - stereo_geom --help
+    - request_planetary_altimetry --help
+    - gallery --help
 
 about:
   home: https://github.com/uw-cryo/asp_plot


### PR DESCRIPTION
Version bump to 2.0.0 **plus the manual fixes the autotick bot cannot make** — this feedstock has not uploaded a package since v1.15.1 (2026-06-11), even though the bot PRs #16 through #20 were all merged.

## Why nothing has uploaded since 1.15.1

`pyyaml` became a runtime dependency of `asp_plot` in upstream v1.16.0 but was never added here. The bot bumps only `version` and `sha256`, so every build since has compiled successfully and then failed its own test phase:

```
+ asp_plot --help
  File ".../asp_plot/selections.py", line 25, in <module>
    import yaml
ModuleNotFoundError: No module named 'yaml'
WARNING: Tests failed for asp-plot-1.19.0-pyhd8ed1ab_0.conda - moving package to .../broken
```

conda-build moves a test-failing package to `broken/` and uploads nothing, so the only outward symptom was a red check on the default branch. anaconda.org has been serving 1.15.1 for five releases.

## Changes

| Change | Reason |
|---|---|
| `pyyaml` added to `run:` | **the fix for the failure above** (upstream v1.16.0) |
| `sliderule` pinned `>=5.3.0` | matches upstream `pyproject.toml` |
| entry point `asp_plot` → `asp_report` | upstream 2.0.0 renamed the report CLI; `asp_plot.cli.asp_plot` no longer exists, so the old entry point would fail even once `pyyaml` is present |
| `request_planetary_altimetry` + `gallery` entry points added | present upstream since v1.13.0 / v1.18.0, never mirrored here — conda users have not been getting these commands |
| `test: commands:` now covers all five console scripts | so a future entry-point drift fails loudly here instead of shipping a broken script |

Upstream release: <https://github.com/uw-cryo/asp_plot/releases/tag/v2.0.0> · changelog entry for the CLI rename: <https://github.com/uw-cryo/asp_plot/blob/main/CHANGELOG.md>

## Checklist

- [x] Used a personal fork of the feedstock to propose changes
- [x] Bumped the build number (reset to 0 for the new version)
- [x] Reset the build number to 0 (new version)
- [x] Re-rendered with the latest conda-smithy — **not required**: `noarch: python`, `python_min` and the CI matrix are unchanged; only `run:` deps, `entry_points:` and `test:` changed
- [x] Ensured the license file is packaged (`LICENSE` confirmed present in the 2.0.0 sdist)
- [x] `sha256` verified against the downloaded sdist, not just the PyPI JSON API
- [x] All five `--help` commands verified against an install of 2.0.0

@conda-forge-admin, please ping bpurinton